### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -206,6 +206,8 @@ jobs:
     needs: [check-skip, version-bump]
     if: needs.check-skip.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/amitray007/etsy-python-sdk/security/code-scanning/3](https://github.com/amitray007/etsy-python-sdk/security/code-scanning/3)

To fix this problem, we should add an explicit `permissions` block with the minimum viable privilege to the `build` job in `.github/workflows/python-publish.yml`. Since the `build` job requires the ability to clone the repository (done via `actions/checkout`), `contents: read` is sufficient; no write or additional permissions are needed (it does not push, manage issues, manipulate PRs, etc.).  
Add the following lines to the `build` job definition, just after the `runs-on: ubuntu-latest` line:

```yaml
permissions:
  contents: read
```

No new imports, methods, or definitions are required. Only the existing YAML block for the `build:` job needs a permissions block inserted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
