### PR TITLE
Sync SDK with Etsy API spec — batch inventory & shipping endpoints

### DIFF
--- a/etsy_python/v3/resources/Listing.py
+++ b/etsy_python/v3/resources/Listing.py
@@ -168,6 +168,24 @@ class ListingResource:
         )
         return self.get_listings_by_listing_ids(listing_ids, includes, legacy)
 
+    def get_listings_inventory_by_listing_ids(
+        self, listing_ids: List[int]
+    ) -> Union[Response, RequestException]:
+        endpoint = "/listings/batch/inventory"
+        query_params: Dict[str, Any] = {
+            "listing_ids": ",".join(list(map(str, listing_ids))),
+        }
+        return self.session.make_request(endpoint, query_params=query_params)
+
+    def get_listings_shipping_by_listing_ids(
+        self, listing_ids: List[int]
+    ) -> Union[Response, RequestException]:
+        endpoint = "/listings/batch/shipping"
+        query_params: Dict[str, Any] = {
+            "listing_ids": ",".join(list(map(str, listing_ids))),
+        }
+        return self.session.make_request(endpoint, query_params=query_params)
+
     def get_featured_listings_by_shop(
         self, shop_id: int, limit: int = 25, offset: int = 0,
         legacy: Optional[bool] = None,

--- a/specs/baseline.json
+++ b/specs/baseline.json
@@ -2673,6 +2673,16 @@
               }
             }
           },
+          "409": {
+            "description": "There was a request conflict with the current state of the target resource. See the error message for details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
           "500": {
             "description": "The server encountered an internal error. See the error message for details.",
             "content": {
@@ -2689,6 +2699,82 @@
             "api_key": [],
             "oauth2": [
               "listings_w"
+            ]
+          }
+        ]
+      }
+    },
+    "/v3/application/listings/batch/inventory": {
+      "get": {
+        "operationId": "getListingsInventoryByListingIds",
+        "description": "<div class=\"wt-display-flex-xs wt-align-items-center wt-mt-xs-2 wt-mb-xs-3\"><span class=\"wt-badge wt-badge--notificationPrimary wt-bg-slime-tint wt-mr-xs-2\">General Release</span><a class=\"wt-text-link\" href=\"https://github.com/etsy/open-api/discussions\" target=\"_blank\" rel=\"noopener noreferrer\">Report bug</a></div><div class=\"wt-display-flex-xs wt-align-items-center wt-mt-xs-2 wt-mb-xs-3\"><p class=\"wt-text-body-01 banner-text\">This endpoint is ready for production use.</p></div>\n\nRetrieves the inventory record for each listing referenced by listing ID. Requires the listings_r OAuth scope. Limit 100 listing IDs per request.",
+        "tags": [
+          "ShopListing Inventory"
+        ],
+        "parameters": [
+          {
+            "name": "listing_ids",
+            "in": "query",
+            "description": "The list of numeric IDS for the listings in a specific Etsy shop.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "description": "The list of numeric IDS for the listings in a specific Etsy shop.",
+              "items": {
+                "type": "integer",
+                "format": "int64",
+                "minimum": 1
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of listings with their inventory records.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShopListingsWithAssociations"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "There was a problem with the request data. See the error message for details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "A resource could not be found. See the error message for details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The server encountered an internal error. See the error message for details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [],
+            "oauth2": [
+              "listings_r"
             ]
           }
         ]
@@ -3935,6 +4021,82 @@
             }
           }
         }
+      }
+    },
+    "/v3/application/listings/batch/shipping": {
+      "get": {
+        "operationId": "getListingsShippingByListingIds",
+        "description": "<div class=\"wt-display-flex-xs wt-align-items-center wt-mt-xs-2 wt-mb-xs-3\"><span class=\"wt-badge wt-badge--notificationPrimary wt-bg-slime-tint wt-mr-xs-2\">General Release</span><a class=\"wt-text-link\" href=\"https://github.com/etsy/open-api/discussions\" target=\"_blank\" rel=\"noopener noreferrer\">Report bug</a></div><div class=\"wt-display-flex-xs wt-align-items-center wt-mt-xs-2 wt-mb-xs-3\"><p class=\"wt-text-body-01 banner-text\">This endpoint is ready for production use.</p></div>\n\nRetrieves the shipping profile for each listing referenced by listing ID. Requires the shops_r OAuth scope. Limit 100 listing IDs per request.",
+        "tags": [
+          "ShopListing"
+        ],
+        "parameters": [
+          {
+            "name": "listing_ids",
+            "in": "query",
+            "description": "The list of numeric IDS for the listings in a specific Etsy shop.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "description": "The list of numeric IDS for the listings in a specific Etsy shop.",
+              "items": {
+                "type": "integer",
+                "format": "int64",
+                "minimum": 1
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of listings with their shipping profiles.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShopListingsWithAssociations"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "There was a problem with the request data. See the error message for details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "A resource could not be found. See the error message for details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The server encountered an internal error. See the error message for details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [],
+            "oauth2": [
+              "shops_r"
+            ]
+          }
+        ]
       }
     },
     "/v3/application/shops/{shop_id}/listings/{listing_id}/transactions": {
@@ -12915,6 +13077,11 @@
             "type": "string",
             "description": "A description string of the product for sale in the listing."
           },
+          "rich_description": {
+            "type": "string",
+            "description": "The seller-authored HTML rich-text description of the product when the listing uses rich text; null for plain-text listings. The plain-text `description` field is always populated. This value is HTML and consumers MUST sanitize it before rendering it in any HTML context.",
+            "nullable": true
+          },
           "state": {
             "type": "string",
             "description": "When _updating_ a listing, this value can be either `active` or `inactive`. Note: Setting a `draft` listing to `active` will also publish the listing on etsy.com and requires that the listing have an image set. Setting a `sold_out` listing to active will update the quantity to 1 and renew the listing on etsy.com.",
@@ -13377,6 +13544,11 @@
           "description": {
             "type": "string",
             "description": "A description string of the product for sale in the listing."
+          },
+          "rich_description": {
+            "type": "string",
+            "description": "The seller-authored HTML rich-text description of the product when the listing uses rich text; null for plain-text listings. The plain-text `description` field is always populated. This value is HTML and consumers MUST sanitize it before rendering it in any HTML context.",
+            "nullable": true
           },
           "state": {
             "type": "string",

--- a/tests/test_listing_resource.py
+++ b/tests/test_listing_resource.py
@@ -310,6 +310,58 @@ class TestGetListingsByListingsIds:
         assert qp["legacy"] is True
 
 
+class TestGetListingsInventoryByListingIds:
+    def test_listing_ids_joined(self, mock_session):
+        mock_session.make_request.return_value = Response(
+            200, make_shop_listing_collection()
+        )
+        resource = ListingResource(session=mock_session)
+
+        resource.get_listings_inventory_by_listing_ids([111, 222, 333])
+
+        endpoint = mock_session.make_request.call_args[0][0]
+        qp = mock_session.make_request.call_args[1]["query_params"]
+        assert endpoint == "/listings/batch/inventory"
+        assert qp["listing_ids"] == "111,222,333"
+
+    def test_single_listing_id(self, mock_session):
+        mock_session.make_request.return_value = Response(
+            200, make_shop_listing_collection()
+        )
+        resource = ListingResource(session=mock_session)
+
+        resource.get_listings_inventory_by_listing_ids([111])
+
+        qp = mock_session.make_request.call_args[1]["query_params"]
+        assert qp["listing_ids"] == "111"
+
+
+class TestGetListingsShippingByListingIds:
+    def test_listing_ids_joined(self, mock_session):
+        mock_session.make_request.return_value = Response(
+            200, make_shop_listing_collection()
+        )
+        resource = ListingResource(session=mock_session)
+
+        resource.get_listings_shipping_by_listing_ids([111, 222, 333])
+
+        endpoint = mock_session.make_request.call_args[0][0]
+        qp = mock_session.make_request.call_args[1]["query_params"]
+        assert endpoint == "/listings/batch/shipping"
+        assert qp["listing_ids"] == "111,222,333"
+
+    def test_single_listing_id(self, mock_session):
+        mock_session.make_request.return_value = Response(
+            200, make_shop_listing_collection()
+        )
+        resource = ListingResource(session=mock_session)
+
+        resource.get_listings_shipping_by_listing_ids([111])
+
+        qp = mock_session.make_request.call_args[1]["query_params"]
+        assert qp["listing_ids"] == "111"
+
+
 class TestGetFeaturedListingsByShop:
     def test_basic_call(self, mock_session):
         mock_session.make_request.return_value = Response(


### PR DESCRIPTION
## Summary

SDK coverage audit against the latest Etsy OAS spec surfaced two GET batch endpoints missing from the SDK. This PR adds them, bringing OAS coverage from **98.1% → 100%**.

**Should Fix — 2 items (implemented):**
- `getListingsInventoryByListingIds` → `get_listings_inventory_by_listing_ids`
  `GET /v3/application/listings/batch/inventory`
- `getListingsShippingByListingIds` → `get_listings_shipping_by_listing_ids`
  `GET /v3/application/listings/batch/shipping`

Both take a single required `listing_ids` query param (array of int64), comma-joined, following the existing `get_listings_by_listing_ids` batch pattern.

**Informational (no code change):**
- `rich_description` added to `ShopListing` / `ShopListingWithAssociations` — response-only field; the SDK does not model response schemas, so no change needed.
- Personalization-field deprecation notices on `createDraftListing` / `updateListing` are pre-existing; Etsy has not removed the fields.

**Audit suppressions:** all 11 re-verified as still valid (4 deprecated aliases + holiday_id/State/Includes enum decisions); 0 stale ignores; no newly-surfaced enum values. `specs/audit-ignore.json` unchanged.

The spec baseline (`specs/baseline.json`) was refreshed to the latest spec.

## Test plan

- [x] `pytest -v` — **344 passed**
- [x] New tests assert both the endpoint URL and the comma-joined `listing_ids` for each method (`TestGetListingsInventoryByListingIds`, `TestGetListingsShippingByListingIds`)
- [x] `python scripts/audit_sdk.py --spec specs/latest.json` — **0 missing, 100% coverage**
- [x] Code review — no critical or important findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)