### PR TITLE
Remove dead Includes enum and fix same-named enum hijacking in SDK audit

### DIFF
--- a/etsy_python/v3/enums/ListingInventory.py
+++ b/etsy_python/v3/enums/ListingInventory.py
@@ -1,10 +1,6 @@
 from enum import Enum
 
 
-class Includes(Enum):
-    LISTING = "listing"
-
-
 class MaxVariationsSupported(Enum):
     TWO = "2"
     THREE = "3"

--- a/scripts/audit_sdk.py
+++ b/scripts/audit_sdk.py
@@ -559,11 +559,19 @@ def compute_enum_findings(
         best_match = None
         matched_values = None
         if expected_enum_name in sdk_enums:
-            best_match = expected_enum_name
-            matched_values, _ = best_candidate(
+            vals, overlap = best_candidate(
                 spec_value_set, sdk_enums[expected_enum_name]
             )
-        else:
+            # Only trust the name match if the values actually correspond. A
+            # same-named enum in another module (e.g. `Includes` for listings
+            # vs. listing-inventory) would otherwise hijack the comparison and
+            # report drift that does not exist. On poor overlap, fall through
+            # to the fuzzy search below, which locates the real enum by value.
+            if overlap > 0:
+                best_match = expected_enum_name
+                matched_values = vals
+
+        if best_match is None:
             best_overlap = 0
             for sdk_name, candidates in sdk_enums.items():
                 vals, overlap = best_candidate(spec_value_set, candidates)
@@ -574,6 +582,23 @@ def compute_enum_findings(
                     best_overlap = overlap
                     best_match = sdk_name
                     matched_values = vals
+
+        if best_match is None:
+            # The overlap floor above needs 2 shared values, so a small spec
+            # enum (e.g. the single-valued getListingInventory.includes) can
+            # never match and would silently escape auditing. Fall back to a
+            # name-suffix match, which pairs `includes` with `InventoryIncludes`
+            # and still reports drift if that enum's values are wrong.
+            suffix_matches = [
+                name
+                for name in sdk_enums
+                if name.endswith(expected_enum_name) and name != expected_enum_name
+            ]
+            if len(suffix_matches) == 1:
+                best_match = suffix_matches[0]
+                matched_values, _ = best_candidate(
+                    spec_value_set, sdk_enums[best_match]
+                )
 
         if not best_match:
             continue

--- a/tests/test_audit_ignore.py
+++ b/tests/test_audit_ignore.py
@@ -278,6 +278,56 @@ class TestComputeEnumFindings:
         assert findings[0]["direction"] == "extra"
         assert findings[0]["values"] == {"d"}
 
+    def test_same_named_unrelated_enum_does_not_hijack(self):
+        # `includes` resolves by name to `Includes`, but that class (the listing
+        # enum) shares no values with this spec enum. The matcher must reject the
+        # name match and find `InventoryIncludes` by suffix rather than reporting
+        # every value of the wrong enum as drift.
+        spec = {
+            "components": {
+                "schemas": {"Foo": {"properties": {"includes": {"enum": ["Listing"]}}}}
+            }
+        }
+        sdk_enums = {
+            "Includes": [["Shipping", "Images", "Shop"]],
+            "InventoryIncludes": [["Listing"]],
+        }
+        assert audit_sdk.compute_enum_findings(spec, sdk_enums) == []
+
+    def test_single_value_enum_drift_still_detected(self):
+        # The fuzzy-overlap floor requires 2 shared values, so a single-valued
+        # spec enum could otherwise escape auditing entirely. Real drift on
+        # `InventoryIncludes` must still surface.
+        spec = {
+            "components": {
+                "schemas": {"Foo": {"properties": {"includes": {"enum": ["Listing"]}}}}
+            }
+        }
+        sdk_enums = {
+            "Includes": [["Shipping", "Images", "Shop"]],
+            "InventoryIncludes": [["WrongValue"]],
+        }
+        findings = audit_sdk.compute_enum_findings(spec, sdk_enums)
+        directions = {f["direction"]: f["values"] for f in findings}
+        assert directions["missing"] == {"listing"}
+        assert directions["extra"] == {"wrongvalue"}
+        assert all(f["sdk_enum"] == "InventoryIncludes" for f in findings)
+
+    def test_ambiguous_suffix_matches_are_not_guessed(self):
+        # Two plausible suffix candidates: guessing between them could pin drift
+        # on the wrong class, so the matcher must decline rather than pick one.
+        spec = {
+            "components": {
+                "schemas": {"Foo": {"properties": {"includes": {"enum": ["Listing"]}}}}
+            }
+        }
+        sdk_enums = {
+            "Includes": [["Shipping", "Images"]],
+            "InventoryIncludes": [["Listing"]],
+            "OtherIncludes": [["Listing"]],
+        }
+        assert audit_sdk.compute_enum_findings(spec, sdk_enums) == []
+
 
 # --------------------------------------------------------------------------- #
 # compute_param_findings — query/path parameter drift


### PR DESCRIPTION
## Summary

Routine SDK audit against the Etsy OAS spec. The spec itself has not moved — `specs/latest.json` is byte-identical to `baseline.json`, no new Etsy releases since `3.0.0-general-release-2026-03-24`, and the audit reports **105/105 operations covered (100%)** with zero missing endpoints, stubs, extra methods, or code issues.

The audit was clean, but the deeper review pass found two real problems the script structurally cannot detect. Both are fixed here.

### 1. Dead `Includes` enum with an invalid value (`cc70b63`)

`enums/ListingInventory.py` defined `Includes.LISTING = "listing"` (lowercase), while the spec's `getListingInventory` `includes` enum is `["Listing"]`.

The class was unreachable — `resources/ListingInventory.py` imports `InventoryIncludes` from `enums/Listing.py`, which has the correct value. Verified unused before removal: never re-exported (`enums/__init__.py` is empty) and never imported anywhere in git history (`git log -S`), so no working behavior is removed. Anyone who *had* imported it would have been sending an invalid value.

Not an active bug, but a trap: the obvious-looking import from the inventory enum module silently yielded a wrong API value.

### 2. Same-named enum hijacking the audit comparison (`00dbc46`) — the substantive fix

`compute_enum_findings` derived the SDK enum name from the spec property (`includes` → `Includes`) and short-circuited whenever that name existed. For `getListingInventory.includes` this matched the **listing** `Includes` enum rather than `InventoryIncludes`, reporting `missing: listing` plus 9 phantom extras against a perfectly correct SDK — noise on every weekly `maintenance-check.yml` run.

This flaw was pre-existing and had been accidentally masked: the dead enum from #1 sat under the same key and won on overlap. Removing it exposed the bug rather than causing it.

Two changes:
- Reject a name match with **zero value overlap** and fall through to fuzzy search.
- Add a **unique-suffix fallback**. The fuzzy branch requires 2 shared values, so a single-valued spec enum like this one could never match — the first fix alone silenced the false finding but left the operation unaudited entirely. Caught via a negative control (deliberately breaking `InventoryIncludes` and confirming nothing was reported).

Ambiguous suffix matches are declined rather than guessed, so drift is never pinned on the wrong class.

## Test plan

- `pytest` — **408 passed** (405 baseline + 3 new regression tests)
- All 3 new tests verified to **fail against the old matcher** (via `git stash`), confirming real coverage rather than vacuous assertions
- Negative controls both directions: no false finding on the correct SDK; genuine drift on `InventoryIncludes` now surfaces where it was previously invisible
- `audit_sdk.py` re-run: 100% coverage, enums in sync, all 19 suppressions still matching, 0 stale ignores
- All 19 suppressions in `audit-ignore.json` independently re-verified against source — 4 deprecated aliases still delegate and warn; all 8 `legacy` sites still call `warn_removed_legacy_param`, and exactly 14 spec operations still accept `legacy`, matching the recorded rationale
- Cross-checked 105/105 operations for path/verb/param-order correctness and 261 params + 184 body fields for type mismatches — all clean

## Notes

- **API surface:** `Includes` shipped through 1.1.13, so this is technically a breaking import for external users. Judged acceptable — the symbol was never exported and its only value was invalid, so no caller could have used it successfully. Worth a release-note line.
- `fix:` prefix → patch bump (1.1.14). The tooling-only commit carries `[skip ci]`.
